### PR TITLE
chore: pin GitHub Actions to SHA

### DIFF
--- a/.github/workflows/ci-main-tests.yml
+++ b/.github/workflows/ci-main-tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   sast:
     name: Static Security Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read
@@ -17,26 +17,26 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Initialise CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
         with:
           languages: 'javascript'
 
       - name: Run CodeQL
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
 
   sca:
     name: Dependency Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Report all vulnerabilities GitHub security tab
       - name: Report on all vulnerabilities
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -46,7 +46,7 @@ jobs:
 
       # Fail the job on critical vulnerabiliies with fix available
       - name: Fail on critical vulnerabilities
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -56,26 +56,26 @@ jobs:
           exit-code: '1'
 
       - name: Upload scan results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
 
   test:
     name: Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: yarn
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -89,6 +89,6 @@ jobs:
   pass:
     name: All tests pass
     needs: ['sast', 'sca', 'test']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - run: echo ok

--- a/.github/workflows/ci-main-tests.yml
+++ b/.github/workflows/ci-main-tests.yml
@@ -36,7 +36,7 @@ jobs:
 
       # Report all vulnerabilities GitHub security tab
       - name: Report on all vulnerabilities
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true
@@ -44,9 +44,9 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
 
-      # Fail the job on critical vulnerabiliies with fix available
+      # Fail the job on critical vulnerabilities with fix available
       - name: Fail on critical vulnerabilities
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           scan-type: 'fs'
           ignore-unfixed: true


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references from mutable tags/branches to immutable commit SHAs
- Replace `ubuntu-latest` with `ubuntu-24.04` for deterministic runner environments

## Why SHA pinning matters

GitHub Actions tags (like `@v4`, `@v3`) are **mutable Git references** -- a repository owner (or an attacker who compromises a repository) can move a tag to point to a completely different commit at any time. This means a workflow using `actions/checkout@v4` today could silently execute different code tomorrow without any change to your workflow files.

**Branch references like `@master` are especially dangerous** because they track a moving branch head. Every push to the default branch of the action repository changes what your workflow executes. The `aquasecurity/trivy-action@master` references in this repository were following this pattern, meaning any commit merged to trivy-action's master branch would immediately run in our CI -- with full access to our repository secrets and security-events permissions.

By pinning to the exact commit SHA, we ensure:
- **Immutability**: The code that runs is always the exact code we reviewed and approved
- **Supply chain security**: A compromised action tag cannot inject malicious code into our pipelines
- **Auditability**: Changes to action versions appear as explicit diffs in pull requests
- **Compliance**: SHA pinning is a requirement for SLSA and other supply chain security frameworks

The original version is preserved in a comment (e.g., `# v4`) so maintainers can still see which version is pinned and know what to look for when upgrading.

## Changes

| Action | Original ref | Pinned SHA |
|--------|-------------|------------|
| `actions/checkout` | `v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `github/codeql-action/*` | `v2` | `b8d3b6e8af63cde30bdc382c0bc28114f4346c88` |
| `github/codeql-action/upload-sarif` | `v3` | `5c8a8a642e79153f5d047b10ec1cba1d1cc65699` |
| `aquasecurity/trivy-action` | `master` | `57a97c7e7821a5776cebc9bb87c984fa69cba8f1` |
| `actions/setup-node` | `v4` | `49933ea5288caeca8642d1e84afbd3f7d6820020` |
| `actions/cache` | `v3` | `6f8efc29b200d32929f49075959781ed54ec270c` |

All `runs-on: ubuntu-latest` changed to `runs-on: ubuntu-24.04`.

## Test plan

- [ ] Verify CI workflows still pass on this PR
- [ ] Confirm all pinned SHAs match the expected tag/branch targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)